### PR TITLE
feat: attach 'aria-label' for Emojis

### DIFF
--- a/src/pages/rank.tsx
+++ b/src/pages/rank.tsx
@@ -59,7 +59,7 @@ export const RankPage: React.FC = () => {
     return (
         <>
             <h1>Ranking</h1>
-            <desc>If you click the name, you can see the avatar's state. <span role="img">😀</span></desc>
+            <desc>If you click the name, you can see the avatar's state. <span role="img" aria-label="Smiling face">😀</span></desc>
             <hr/>
             {rankingRows}
         </>


### PR DESCRIPTION
It resolves the error log:

```
Compiled with warnings.

./src/pages/rank.tsx
  Line 62:74:  Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
```

See also https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute