### PR TITLE
feat: introduce `mimirGraphQLClient`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-NETWORK_CONF_MAP="<networkType-nodeType>=<graphql-endpoint>,heimdall-internal=http://url/graphql,heimdall-main=http://url/graphql"
+NETWORK_CONF_MAP="<networkType-nodeType>=<graphql-endpoint>,odin-main=http://url/graphql,odin-internal=http://url/graphql"
+MIMIR_GRAPHQL_URL_MAP="<nodeType>=<mimir-graphql-endpoint>,main=https://mimir-internal.nine-chronicles.dev/graphql/"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ And since this information is tied to the `NETWORK_CONF_MAP` value you define in
 
 `https://planetarium-9c-board.netlify.app/[NETWORK]/tablesheet/[TABLESHEET_NAME]`
 
-For instance, you can see current `StakeRegularRewardSheet` of `odin`-`mainnet` network in `https://planetarium-9c-board.netlify.app/odin-main/tablesheet/StakeRegularRewardSheet`.
+For instance, you can see current `StakeRegularRewardSheet` of `odin`-`main` network in `https://planetarium-9c-board.netlify.app/odin-main/tablesheet/StakeRegularRewardSheet`.
 
 <img width="880" alt="image" src="https://user-images.githubusercontent.com/26626194/224272344-622e9d80-a74c-48bf-82b6-62f1e8dde3f1.png">
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A web application to provide useful tools. You can access it in https://9c-board
 
 ```
 # Set network config map e.g.,
-NETWORK_CONF_MAP="<networkType-nodeType>=<graphql-endpoint>,heimdall-internal=http://url/graphql,heimdall-main=http://url/graphql"
+NETWORK_CONF_MAP="<networkType-nodeType>=<graphql-endpoint>,odin-main=http://url/graphql,odin-internal=http://url/graphql"
+MIMIR_GRAPHQL_URL_MAP="<nodeType>=<mimir-graphql-endpoint>,main=https://mimir-internal.nine-chronicles.dev/graphql/"
 ```
 
 ### Run
@@ -26,18 +27,19 @@ yarn dev
 ### Planets & Networks
 
 NineChronicle's blockchain network is divided into planets, which can be found below.
+
 - main network: https://planets.nine-chronicles.com/planets
 - internal network: https://planets-internal.nine-chronicles.com/planets
 
 As you can see above, NineChronicle's planets are divided into main and internal networks for deployment purposes.
 Therefore, each of the features provided here must be used separately for each planet and network.
 
-This is a common way to determine what goes into the '[NETWORK]' location in the URL of a feature, which we'll discuss below. 
+This is a common way to determine what goes into the '[NETWORK]' location in the URL of a feature, which we'll discuss below.
 
-||main|internal|
-|:-:|:-:|:-:|
-|odin|odin|odin-internal|
-|heimdall|heimdall|heimdall-internal|
+|          |     main      |     internal      |
+| :------: | :-----------: | :---------------: |
+|   odin   |   odin-main   |   odin-internal   |
+| heimdall | heimdall-main | heimdall-internal |
 
 And since this information is tied to the `NETWORK_CONF_MAP` value you define in your `.env` file, you can change it.
 
@@ -45,7 +47,7 @@ And since this information is tied to the `NETWORK_CONF_MAP` value you define in
 
 `https://planetarium-9c-board.netlify.app/[NETWORK]/tablesheet/[TABLESHEET_NAME]`
 
-For instance, you can see current `StakeRegularRewardSheet` of `odin`-`mainnet` network in `https://planetarium-9c-board.netlify.app/odin/tablesheet/StakeRegularRewardSheet`.
+For instance, you can see current `StakeRegularRewardSheet` of `odin`-`mainnet` network in `https://planetarium-9c-board.netlify.app/odin-main/tablesheet/StakeRegularRewardSheet`.
 
 <img width="880" alt="image" src="https://user-images.githubusercontent.com/26626194/224272344-622e9d80-a74c-48bf-82b6-62f1e8dde3f1.png">
 

--- a/pages/[network]/tablesheet/[name].tsx
+++ b/pages/[network]/tablesheet/[name].tsx
@@ -1,6 +1,6 @@
 import type { NextPage, GetServerSideProps } from "next";
-import { getSheet } from "../../../apiClient";
 import { getNetworkType, getNodeType } from "../../../utils/network";
+import { getSdk } from "../../../utils/mimirGraphQLClient";
 
 interface TableSheetPageProps {
   tableSheet: string | null;
@@ -57,14 +57,14 @@ const TableSheetPage: NextPage<TableSheetPageProps> = ({ tableSheet }) => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const network_info = context.query.network as string;
-  const name = context.query.name as string;
+  const sheetName = context.query.name as string;
 
   try {
-    const sheet = await getSheet(
-      getNodeType(network_info),
+    const sdk = getSdk(
       getNetworkType(network_info),
-      name
-    );
+      getNodeType(network_info));
+    const sheet = await sdk.sheet(sheetName);
+
     return { props: { tableSheet: sheet } };
   } catch (error) {
     console.error("Error fetching sheet:", error);

--- a/pages/[network]/tablesheet/index.tsx
+++ b/pages/[network]/tablesheet/index.tsx
@@ -1,17 +1,18 @@
 import type { NextPage, GetServerSideProps } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { getSheetNames } from "../../../apiClient";
 import { getNetworkType, getNodeType } from "../../../utils/network";
+import { getSdk } from "../../../utils/mimirGraphQLClient";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const network_info = context.query.network as string;
 
   try {
-    const sheetNames = await getSheetNames(
-      getNodeType(network_info),
-      getNetworkType(network_info)
-    );
+    const sdk = getSdk(
+      getNetworkType(network_info),
+      getNodeType(network_info));
+    const sheetNames = await sdk.sheetNames();
+
     return { props: { sheetNames } };
   } catch (error) {
     console.error("Error fetching sheet names:", error);

--- a/utils/mimirGraphQLClient.ts
+++ b/utils/mimirGraphQLClient.ts
@@ -40,20 +40,24 @@ export function getSdk(networkType: NetworkType, nodeType: NodeType) {
   const client = getClient(nodeType);
   return {
     client,
-    sheetNames: async () => {
-      const query = `query {
-                    sheetNames(planetName: ${planetName})
-                }`;
+    sheetNames: () => {
+      const query = `
+        query {
+            sheetNames(planetName: ${planetName})
+        }
+      `;
       return client
         .request(query, undefined, { accept: "application/json" })
         .then((data) => data.sheetNames);
     },
-    sheet: async (sheetName: string) => {
-      const query = `query {
-                    sheet(planetName: ${planetName}, sheetName: "${sheetName}") {
-                        csv
-                    }
-                }`;
+    sheet: (sheetName: string) => {
+      const query = `
+        query {
+            sheet(planetName: ${planetName}, sheetName: "${sheetName}") {
+                csv
+            }
+        }
+      `;
       return client
         .request(query, undefined, { accept: "application/json" })
         .then((data) => data.sheet.csv);

--- a/utils/mimirGraphQLClient.ts
+++ b/utils/mimirGraphQLClient.ts
@@ -1,52 +1,62 @@
 import { GraphQLClient } from "graphql-request";
 import { NetworkType, NodeType } from "../constants/network";
 
-function getUrl(nodeType: NodeType)
-{
-    const map = process.env.MIMIR_GRAPHQL_URL_MAP;
-    if (map === undefined) {
-        throw new Error("MIMIR_GRAPHQL_URL_MAP is not set.");
+function getUrl(nodeType: NodeType) {
+  const map = process.env.MIMIR_GRAPHQL_URL_MAP;
+  if (map === undefined) {
+    throw new Error("MIMIR_GRAPHQL_URL_MAP is not set.");
+  }
+
+  if (map === "") {
+    throw new Error("MIMIR_GRAPHQL_URL_MAP is empty.");
+  }
+
+  const pairs = map.split(",").map((pair) => {
+    if (pair.indexOf("=") === -1) {
+      throw new Error(
+        "MIMIR_GRAPHQL_URL_MAP is not well-formed." +
+          " It should be a comma-separated list of key-value pairs."
+      );
     }
 
-    const pairs = map.split(',').map((pair) => pair.split('='));
-    for (const [key, value] of pairs) {
-        if (key === nodeType) {
-            return value;
-        }
+    return pair.split("=");
+  });
+  for (const [key, value] of pairs) {
+    if (key === nodeType) {
+      return value;
     }
+  }
 
-    throw new Error("There is no such network: " + nodeType);
+  throw new Error("There is no such network: " + nodeType);
 }
 
-export function getClient(nodeType: NodeType)
-{
-    const url = getUrl(nodeType);
-    return new GraphQLClient(url);
+export function getClient(nodeType: NodeType) {
+  const url = getUrl(nodeType);
+  return new GraphQLClient(url);
 }
 
-export function getSdk(networkType: NetworkType, nodeType: NodeType)
-{
-    const planetName = networkType.toUpperCase();
-    const client = getClient(nodeType);
-    return {
-        client,
-        sheetNames: async () => {
-            const query = `query {
+export function getSdk(networkType: NetworkType, nodeType: NodeType) {
+  const planetName = networkType.toUpperCase();
+  const client = getClient(nodeType);
+  return {
+    client,
+    sheetNames: async () => {
+      const query = `query {
                     sheetNames(planetName: ${planetName})
                 }`;
-            return client
-                .request(query, undefined, { accept: "application/json" })
-                .then((data) => data.sheetNames);
-        },
-        sheet: async (sheetName: string) => {
-            const query = `query {
+      return client
+        .request(query, undefined, { accept: "application/json" })
+        .then((data) => data.sheetNames);
+    },
+    sheet: async (sheetName: string) => {
+      const query = `query {
                     sheet(planetName: ${planetName}, sheetName: "${sheetName}") {
                         csv
                     }
                 }`;
-            return client
-                .request(query, undefined, { accept: "application/json" })
-                .then((data) => data.sheet.csv);
-        }
-    }
+      return client
+        .request(query, undefined, { accept: "application/json" })
+        .then((data) => data.sheet.csv);
+    },
+  };
 }

--- a/utils/mimirGraphQLClient.ts
+++ b/utils/mimirGraphQLClient.ts
@@ -1,0 +1,52 @@
+import { GraphQLClient } from "graphql-request";
+import { NetworkType, NodeType } from "../constants/network";
+
+function getUrl(nodeType: NodeType)
+{
+    const map = process.env.MIMIR_GRAPHQL_URL_MAP;
+    if (map === undefined) {
+        throw new Error("MIMIR_GRAPHQL_URL_MAP is not set.");
+    }
+
+    const pairs = map.split(',').map((pair) => pair.split('='));
+    for (const [key, value] of pairs) {
+        if (key === nodeType) {
+            return value;
+        }
+    }
+
+    throw new Error("There is no such network: " + nodeType);
+}
+
+export function getClient(nodeType: NodeType)
+{
+    const url = getUrl(nodeType);
+    return new GraphQLClient(url);
+}
+
+export function getSdk(networkType: NetworkType, nodeType: NodeType)
+{
+    const planetName = networkType.toUpperCase();
+    const client = getClient(nodeType);
+    return {
+        client,
+        sheetNames: async () => {
+            const query = `query {
+                    sheetNames(planetName: ${planetName})
+                }`;
+            return client
+                .request(query, undefined, { accept: "application/json" })
+                .then((data) => data.sheetNames);
+        },
+        sheet: async (sheetName: string) => {
+            const query = `query {
+                    sheet(planetName: ${planetName}, sheetName: "${sheetName}") {
+                        csv
+                    }
+                }`;
+            return client
+                .request(query, undefined, { accept: "application/json" })
+                .then((data) => data.sheet.csv);
+        }
+    }
+}


### PR DESCRIPTION
- Update `README` and `.env.example`
- Introduce `mimirGraphQLClient`
- Use `mimirGraphQLClient` to "{network}/tablesheet"
- Use `mimirGraphQLClient` to "{network}/tablesheet/{name}"