### PR TITLE
feat: adjust way to setup network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 NETWORK_CONF_MAP="<networkType-nodeType>=<graphql-endpoint>,odin-main=http://url/graphql,odin-internal=http://url/graphql"
-MIMIR_GRAPHQL_URL_MAP="<nodeType>=<mimir-graphql-endpoint>,main=https://mimir-internal.nine-chronicles.dev/graphql/"
+MIMIR_GRAPHQL_URL_MAP="<network>=<mimir-graphql-endpoint>"

--- a/README.md
+++ b/README.md
@@ -36,24 +36,24 @@ Therefore, each of the features provided here must be used separately for each p
 
 This is a common way to determine what goes into the '[NETWORK]' location in the URL of a feature, which we'll discuss below.
 
-|          |     main      |     internal      |
-| :------: | :-----------: | :---------------: |
-|   odin   |   odin-main   |   odin-internal   |
-| heimdall | heimdall-main | heimdall-internal |
+|          |   main   |     internal      |
+| :------: | :------: | :---------------: |
+|   odin   |   odin   |   odin-internal   |
+| heimdall | heimdall | heimdall-internal |
 
-And since this information is tied to the `NETWORK_CONF_MAP` value you define in your `.env` file, you can change it.
+And since this information is tied to the `NETWORK_CONF_MAP` value and `MIMIR_GRAPHQL_URL_MAP` value you define in your `.env` file, you can change it.
 
 ### Show tablesheet in web
 
-`https://planetarium-9c-board.netlify.app/[NETWORK]/tablesheet/[TABLESHEET_NAME]`
+`https://9c-board.nine-chronicles.dev/[NETWORK]/tablesheet/[TABLESHEET_NAME]`
 
-For instance, you can see current `StakeRegularRewardSheet` of `odin`-`main` network in `https://planetarium-9c-board.netlify.app/odin-main/tablesheet/StakeRegularRewardSheet`.
+For instance, you can see current `StakeRegularRewardSheet` of `odin` network in `https://9c-board.nine-chronicles.dev/odin/tablesheet/StakeRegularRewardSheet`.
 
 <img width="880" alt="image" src="https://user-images.githubusercontent.com/26626194/224272344-622e9d80-a74c-48bf-82b6-62f1e8dde3f1.png">
 
 ### Show avatar in web
 
-`https://planetarium-9c-board.netlify.app/[NETWORK]/avatar/[AVATAR_ADDRESS]?<index=[BLOCK_INDEX]>`
+`https://9c-board.nine-chronicles.dev/[NETWORK]/avatar/[AVATAR_ADDRESS]?<index=[BLOCK_INDEX]>`
 
 You can see some avatar state in web.
 

--- a/constants/network.ts
+++ b/constants/network.ts
@@ -1,9 +1,7 @@
-export enum NetworkType {
-  Odin = "odin",
-  Heimdall = "heimdall",
-}
+// export enum NetworkType {
+//   Odin = "odin",
+//   Heimdall = "heimdall",
+// }
 
-export enum NodeType {
-  Internal = "internal",
-  Main = "main",
-}
+export type ValidatedNetwork = "odin" | "heimdall" | "odin-internal" | "heimdall-internal";
+export type Network = string;

--- a/graphql/mimir/api.graphql
+++ b/graphql/mimir/api.graphql
@@ -1,5 +1,5 @@
-query GetAgent($planetName: PlanetName!, $agentAddress: Address!) {
-    agent(planetName: $planetName, address: $agentAddress)
+query GetAgent($agentAddress: Address!) {
+    agent(address: $agentAddress)
     {
         avatars
         {
@@ -11,20 +11,20 @@ query GetAgent($planetName: PlanetName!, $agentAddress: Address!) {
     }
 }
 
-query GetSheetNames($planetName: PlanetName!) {
-    sheetNames(planetName: $planetName)
+query GetSheetNames {
+    sheetNames
 }
 
-query GetSheet($planetName: PlanetName!, $sheetName: SheetNameType!) {
-    sheet(planetName: $planetName, sheetName: $sheetName) {
+query GetSheet($sheetName: SheetNameType!) {
+    sheet(sheetName: $sheetName) {
         csv
     }
 }
 
 # TODO: GetBalance
 
-query GetAvatar($planetName: PlanetName!, $avatarAddress: Address!) {
-  avatar(planetName: $planetName, address: $avatarAddress) {
+query GetAvatar($avatarAddress: Address!) {
+  avatar(address: $avatarAddress) {
     agentAddress
     address
     name

--- a/graphql/mimir/schema.graphql
+++ b/graphql/mimir/schema.graphql
@@ -1,107 +1,151 @@
 scalar Address
 
-enum ElementalType {
-  NORMAL
-  FIRE
-  WATER
-  LAND
-  WIND
+type FungibleAssetValue {
+  rawValue: String!
+  quantity: String!
+  ticker: String!
+  decimalPlaces: Byte!
 }
 
-interface IFungibleItem implements IItem {
+interface IFungibleItem {
   """
   The fungible ID of the item.
   """
   fungibleId: HashDigestSHA256!
-
-  """
-  The ItemType of the item.
-  """
-  itemType: ItemType!
-
-  """
-  The ItemSubType of the item.
-  """
-  itemSubType: ItemSubType!
 }
 
 scalar Guid
 
 scalar HashDigestSHA256
 
-enum ItemSubType {
-  FOOD
-  FULL_COSTUME
-  HAIR_COSTUME
-  EAR_COSTUME
-  EYE_COSTUME
-  TAIL_COSTUME
-  WEAPON
-  ARMOR
-  BELT
-  NECKLACE
-  RING
-  EQUIPMENT_MATERIAL
-  FOOD_MATERIAL
-  MONSTER_PART
-  NORMAL_MATERIAL
-  HOURGLASS
-  AP_STONE
-  CHEST
-    @deprecated(
-      reason: "ItemSubType.Chest has never been used outside the MaterialItemSheet. And we won't use it in the future until we have a specific reason."
-    )
-  TITLE
-  AURA
-}
-
-interface IItem {
-  """
-  The ItemType of the item.
-  """
-  itemType: ItemType!
-
-  """
-  The ItemSubType of the item.
-  """
-  itemSubType: ItemSubType!
-}
-
-enum ItemType {
-  CONSUMABLE
-  COSTUME
-  EQUIPMENT
-  MATERIAL
-}
-
-interface INonFungibleItem implements IItem {
+interface INonFungibleItem {
   """
   The non-fungible ID of the item.
   """
   nonFungibleId: Guid!
   requiredBlockIndex: Long!
-
-  """
-  The ItemType of the item.
-  """
-  itemType: ItemType!
-
-  """
-  The ItemSubType of the item.
-  """
-  itemSubType: ItemSubType!
-}
-
-enum PlanetName {
-  ODIN
-  HEIMDALL
 }
 
 scalar SheetNameType
 
-interface ITradableItem implements IItem {
+type Row {
+  id: Int!
+  elementalType: ElementalType!
+  skillType: SkillType!
+  skillCategory: SkillCategory!
+  skillTargetType: SkillTargetType!
+  hitCount: Int!
+  cooldown: Int!
+  combo: Boolean!
+}
+
+type StatMap {
+  hp: Long!
+  atk: Long!
+  def: Long!
+  cri: Long!
+  hit: Long!
+  spd: Long!
+  drv: Long!
+  drr: Long!
+  cdmg: Long!
+  armorPenetration: Long!
+  thorn: Long!
+  baseHP: Long!
+  baseATK: Long!
+  baseDEF: Long!
+  baseCRI: Long!
+  baseHIT: Long!
+  baseSPD: Long!
+  baseDRV: Long!
+  baseDRR: Long!
+  baseCDMG: Long!
+  baseArmorPenetration: Long!
+  baseThorn: Long!
+  additionalHP: Long!
+  additionalATK: Long!
+  additionalDEF: Long!
+  additionalCRI: Long!
+  additionalHIT: Long!
+  additionalSPD: Long!
+  additionalDRV: Long!
+  additionalDRR: Long!
+  additionalCDMG: Long!
+  additionalArmorPenetration: Long!
+  additionalThorn: Long!
+}
+
+interface ITradableItem {
   tradableId: UUID!
   requiredBlockIndex: Long!
+}
+
+type AgentObject {
+  address: Address!
+  version: Int
+  avatarAddresses: [Address!]
+  monsterCollectionRound: Int
+  avatar(
+    """
+    The index of the avatar in the agent. (0 ~ 2).
+    """
+    index: Int!
+  ): AvatarObject
+  avatars: [AvatarObject!]!
+  stake: StakeStateV2
+}
+
+type RoundData {
+  championshipId: Int!
+  round: Int!
+  arenaType: ArenaType!
+  startBlockIndex: Long!
+  endBlockIndex: Long!
+  requiredMedalCount: Int!
+  entranceFee: Long!
+  ticketPrice: Long!
+  additionalTicketPrice: Long!
+  maxPurchaseCount: Int!
+  maxPurchaseCountWithInterval: Int!
+}
+
+type ArenaObject {
+  """
+  The round of the arena.
+  """
+  round: RoundData
+
+  """
+  The avatar's ranking of the arena.
+  """
+  ranking(avatarAddress: Address!): Long
+
+  """
+  The leaderboard of the arena.
+  """
+  leaderboard(
+    """
+    The ranking of the first avatar. default is 1. This must be greater than or equal to 1.
+    """
+    ranking: Long! = 1
+
+    """
+    The number of avatars. default is 10. This must be greater than or equal to 1 and less than or equal to 100.
+    """
+    length: Int! = 10
+  ): [ArenaRanking]
+}
+
+type Armor {
+  """
+  The ItemSheet ID of the item.
+  """
+  equipmentItemId: Guid!
+
+  """
+  The grade of the item.
+  """
+  grade: Int!
 
   """
   The ItemType of the item.
@@ -112,15 +156,88 @@ interface ITradableItem implements IItem {
   The ItemSubType of the item.
   """
   itemSubType: ItemSubType!
+
+  """
+  The ElementalType of the item.
+  """
+  elementalType: ElementalType!
+
+  """
+  The level of the item.
+  """
+  level: Int
+
+  """
+  The exp of the item.
+  """
+  exp: Long
+
+  """
+  The required block index of the item.
+  """
+  requiredBlockIndex: Int
+
+  """
+  The equipped status of the item.
+  """
+  equipped: Boolean
+
+  """
+  The main stat type of the item.
+  """
+  stat: DecimalStat
 }
 
-type AgentObject {
-  version: Int
-  address: Address!
-  avatarAddresses: [Address!]!
-  monsterCollectionRound: Int
-  avatar(index: Int!): AvatarObject
-  avatars: [AvatarObject!]!
+type Aura {
+  """
+  The ItemSheet ID of the item.
+  """
+  equipmentItemId: Guid!
+
+  """
+  The grade of the item.
+  """
+  grade: Int!
+
+  """
+  The ItemType of the item.
+  """
+  itemType: ItemType!
+
+  """
+  The ItemSubType of the item.
+  """
+  itemSubType: ItemSubType!
+
+  """
+  The ElementalType of the item.
+  """
+  elementalType: ElementalType!
+
+  """
+  The level of the item.
+  """
+  level: Int
+
+  """
+  The exp of the item.
+  """
+  exp: Long
+
+  """
+  The required block index of the item.
+  """
+  requiredBlockIndex: Int
+
+  """
+  The equipped status of the item.
+  """
+  equipped: Boolean
+
+  """
+  The main stat type of the item.
+  """
+  stat: DecimalStat
 }
 
 type AvatarObject {
@@ -129,36 +246,203 @@ type AvatarObject {
   index: Int
   name: String
   level: Int
-  inventory: InventoryObject
   actionPoint: Int
-  runes: [RuneObject!]!
-  collection: [CollectionElementObject!]!
+  dailyRewardReceivedBlockIndex: Int
+  inventory: InventoryObject
+  runes: [RuneObject!]
+  collection: [CollectionElementObject!]
+  itemSlots(
+    """
+    The type of battle that the item slot is used for.
+    """
+    battleType: BattleType!
+  ): ItemSlotState
+  runeSlots(
+    """
+    The type of battle that the rune slot is used for.
+    """
+    battleType: BattleType!
+  ): [IRuneSlot]
+}
+
+type Belt {
+  """
+  The ItemSheet ID of the item.
+  """
+  equipmentItemId: Guid!
+
+  """
+  The grade of the item.
+  """
+  grade: Int!
+
+  """
+  The ItemType of the item.
+  """
+  itemType: ItemType!
+
+  """
+  The ItemSubType of the item.
+  """
+  itemSubType: ItemSubType!
+
+  """
+  The ElementalType of the item.
+  """
+  elementalType: ElementalType!
+
+  """
+  The level of the item.
+  """
+  level: Int
+
+  """
+  The exp of the item.
+  """
+  exp: Long
+
+  """
+  The required block index of the item.
+  """
+  requiredBlockIndex: Int
+
+  """
+  The equipped status of the item.
+  """
+  equipped: Boolean
+
+  """
+  The main stat type of the item.
+  """
+  stat: DecimalStat
 }
 
 type CollectionElementObject {
   collectionSheetId: Int!
 }
 
+type Consumable {
+  """
+  The ItemSheet ID of the item.
+  """
+  itemId: Guid!
+
+  """
+  The grade of the item.
+  """
+  grade: Int!
+
+  """
+  The ItemType of the item.
+  """
+  itemType: ItemType!
+
+  """
+  The ItemSubType of the item.
+  """
+  itemSubType: ItemSubType!
+
+  """
+  The ElementalType of the item.
+  """
+  elementalType: ElementalType!
+
+  """
+  The required block index of the item.
+  """
+  requiredBlockIndex: Int
+
+  """
+  The stats of the item.
+  """
+  stats: [DecimalStat]
+}
+
+type Contract {
+  """
+  The name of the table that contains the regular fixed rewards for staking.
+  """
+  stakeRegularFixedRewardSheetTableName: String!
+
+  """
+  The name of the table that contains the regular rewards for staking.
+  """
+  stakeRegularRewardSheetTableName: String!
+
+  """
+  The interval at which rewards are given.
+  """
+  rewardInterval: Long!
+
+  """
+  The interval at which the stake is locked up.
+  """
+  lockupInterval: Long!
+}
+
+type DecimalStat {
+  statType: StatType!
+  baseValue: Decimal!
+  additionalValue: Decimal!
+}
+
+type FavProduct {
+  productId: UUID
+  sellerAgentAddress: Address
+  sellerAvatarAddress: Address
+  price: FungibleAssetValue
+  registeredBlockIndex: Long
+}
+
 type InventoryObject {
+  address: Address!
+
   """
   The consumables in the inventory.
   """
-  consumables: [ItemObject!]!
+  consumables: [ItemObject!]
 
   """
   The costumes in the inventory.
   """
-  costumes: [ItemObject!]!
+  costumes: [ItemObject!]
 
   """
   The equipments in the inventory.
   """
-  equipments: [ItemObject!]!
+  equipments: [ItemObject!]
 
   """
   The materials in the inventory.
   """
-  materials: [ItemObject!]!
+  materials: [ItemObject!]
+}
+
+type ItemProduct {
+  productId: UUID
+  sellerAgentAddress: Address
+  sellerAvatarAddress: Address
+  price: FungibleAssetValue
+  registeredBlockIndex: Long
+  itemCount: Int
+  tradableItem: ItemUsable
+}
+
+type ItemSlotState {
+  """
+  The type of battle that the item slot is used for.
+  """
+  battleType: BattleType!
+
+  """
+  The non-fungible item IDs of the costumes equipped in the item slot.
+  """
+  costumes: [Guid]!
+
+  """
+  The non-fungible item IDs of the equipments equipped in the item slot.
+  """
+  equipments: [Guid]!
 }
 
 type ItemObject {
@@ -193,9 +477,19 @@ type ItemObject {
   count: Int!
 
   """
+  The locked status of the item.
+  """
+  locked: Boolean!
+
+  """
   The level of the item.
   """
   level: Int
+
+  """
+  The exp of the item.
+  """
+  exp: Long
 
   """
   The required block index of the item.
@@ -216,21 +510,225 @@ type ItemObject {
   The Tradable ID of the item.
   """
   tradableId: Guid
+
+  """
+  The equipped status of the item.
+  """
+  equipped: Boolean
+
+  """
+  The main stat type of the item.
+  """
+  mainStatType: StatType
+
+  """
+  The stats map of the item.
+  """
+  statsMap: StatMap
+
+  """
+  The skills of the item.
+  """
+  skills: [SkillObject]
+
+  """
+  The buff skills of the item.
+  """
+  buffSkills: [SkillObject]
 }
 
+type TradableMaterial {
+  """
+  The tradable ID of the item.
+  """
+  tradableId: Guid!
+
+  """
+  The ItemSheet ID of the item.
+  """
+  materialItemId: HashDigestSHA256!
+
+  """
+  The grade of the item.
+  """
+  grade: Int!
+
+  """
+  The ItemType of the item.
+  """
+  itemType: ItemType!
+
+  """
+  The ItemSubType of the item.
+  """
+  itemSubType: ItemSubType!
+
+  """
+  The ElementalType of the item.
+  """
+  elementalType: ElementalType!
+
+  """
+  The required block index of the item.
+  """
+  requiredBlockIndex: Int
+}
+
+type Necklace {
+  """
+  The ItemSheet ID of the item.
+  """
+  equipmentItemId: Guid!
+
+  """
+  The grade of the item.
+  """
+  grade: Int!
+
+  """
+  The ItemType of the item.
+  """
+  itemType: ItemType!
+
+  """
+  The ItemSubType of the item.
+  """
+  itemSubType: ItemSubType!
+
+  """
+  The ElementalType of the item.
+  """
+  elementalType: ElementalType!
+
+  """
+  The level of the item.
+  """
+  level: Int
+
+  """
+  The exp of the item.
+  """
+  exp: Long
+
+  """
+  The required block index of the item.
+  """
+  requiredBlockIndex: Int
+
+  """
+  The equipped status of the item.
+  """
+  equipped: Boolean
+
+  """
+  The main stat type of the item.
+  """
+  stat: DecimalStat
+}
+
+union Product = FavProduct | ItemProduct
+
 type Query {
-  agent(planetName: PlanetName!, address: Address!): AgentObject
-  avatar(planetName: PlanetName!, address: Address!): AvatarObject
-  sheetNames(planetName: PlanetName!): [String!]!
+  agent(address: Address!): AgentObject
+  avatar(address: Address!): AvatarObject
+  inventory(address: Address!): InventoryObject
+  arena: ArenaObject
+  product(skip: Long!, limit: Int!): [Product]
+  sheetNames: [String!]!
   sheet(
-    planetName: PlanetName!
     sheetName: SheetNameType!
     encodeAsBase64: Boolean = false
   ): SheetObject!
 }
 
+type Ring {
+  """
+  The ItemSheet ID of the item.
+  """
+  equipmentItemId: Guid!
+
+  """
+  The grade of the item.
+  """
+  grade: Int!
+
+  """
+  The ItemType of the item.
+  """
+  itemType: ItemType!
+
+  """
+  The ItemSubType of the item.
+  """
+  itemSubType: ItemSubType!
+
+  """
+  The ElementalType of the item.
+  """
+  elementalType: ElementalType!
+
+  """
+  The level of the item.
+  """
+  level: Int
+
+  """
+  The exp of the item.
+  """
+  exp: Long
+
+  """
+  The required block index of the item.
+  """
+  requiredBlockIndex: Int
+
+  """
+  The equipped status of the item.
+  """
+  equipped: Boolean
+
+  """
+  The main stat type of the item.
+  """
+  stat: DecimalStat
+}
+
+type IRuneSlot {
+  """
+  The index of the rune slot.
+  """
+  slotIndex: Int!
+
+  """
+  The type of the rune slot.
+  """
+  runeSlotType: RuneSlotType!
+
+  """
+  The type of the rune.
+  """
+  runeType: RuneType!
+
+  """
+  Whether the rune slot is locked.
+  """
+  isLock: Boolean!
+
+  """
+  The RuneSheet ID of the rune equipped in the rune slot.
+  """
+  runeSheetId: Int
+}
+
 type RuneObject {
+  """
+  The RuneSheet ID of the rune.
+  """
   runeSheetId: Int!
+
+  """
+  The level of the rune.
+  """
   level: Int!
 }
 
@@ -246,9 +744,266 @@ type SheetObject {
   csv: String
 }
 
-scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
+type SkillObject {
+  """
+  The SkillSheet.Row of the skill.
+  """
+  skillRow: Row!
+  power: Long!
+  chance: Int!
+  statPowerRatio: Int!
+  referencedStatType: StatType!
+}
+
+type StakeStateV2 {
+  """
+  The contract of the stake.
+  """
+  Contract: Contract!
+
+  """
+  The block index when the stake started.
+  """
+  StartedBlockIndex: Long!
+
+  """
+  The block index when the stake received. If 0, the stake is not received yet.
+  """
+  ReceivedBlockIndex: Long!
+
+  """
+  The block index when the stake can be cancelled.
+  """
+  cancellableBlockIndex: Long!
+
+  """
+  The block index when the stake can be claimed.
+  """
+  claimableBlockIndex: Long!
+
+  """
+  The block index when the stake was claimed. If 0, the stake is not claimed yet.
+  """
+  claimedBlockIndex: Long!
+}
+
+union ItemUsable =
+  | Armor
+  | Aura
+  | Belt
+  | Necklace
+  | Weapon
+  | Ring
+  | TradableMaterial
+  | Consumable
+
+type Weapon {
+  """
+  The ItemSheet ID of the item.
+  """
+  equipmentItemId: Guid!
+
+  """
+  The grade of the item.
+  """
+  grade: Int!
+
+  """
+  The ItemType of the item.
+  """
+  itemType: ItemType!
+
+  """
+  The ItemSubType of the item.
+  """
+  itemSubType: ItemSubType!
+
+  """
+  The ElementalType of the item.
+  """
+  elementalType: ElementalType!
+
+  """
+  The level of the item.
+  """
+  level: Int
+
+  """
+  The exp of the item.
+  """
+  exp: Long
+
+  """
+  The required block index of the item.
+  """
+  requiredBlockIndex: Int
+
+  """
+  The equipped status of the item.
+  """
+  equipped: Boolean
+
+  """
+  The main stat type of the item.
+  """
+  stat: DecimalStat
+}
+
+"""
+The `Byte` scalar type represents non-fractional whole numeric values. Byte can represent values between 0 and 255.
+"""
+scalar Byte
+
+enum ElementalType {
+  NORMAL
+  FIRE
+  WATER
+  LAND
+  WIND
+}
+
+enum SkillType {
+  ATTACK
+  HEAL
+  BUFF
+  DEBUFF
+}
+
+enum SkillCategory {
+  NORMAL_ATTACK
+  BLOW_ATTACK
+  DOUBLE_ATTACK
+  AREA_ATTACK
+  BUFF_REMOVAL_ATTACK
+  SHATTER_STRIKE
+  HEAL
+  HP_BUFF
+  ATTACK_BUFF
+  DEFENSE_BUFF
+  CRITICAL_BUFF
+  HIT_BUFF
+  SPEED_BUFF
+  DAMAGE_REDUCTION_BUFF
+  CRITICAL_DAMAGE_BUFF
+  BUFF
+  DEBUFF
+  TICK_DAMAGE
+  FOCUS
+  DISPEL
+}
+
+enum SkillTargetType {
+  ENEMY
+  ENEMIES
+  SELF
+  ALLY
+}
 
 """
 The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1.
 """
 scalar Long
+
+scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
+
+type ArenaRanking {
+  avatarAddress: String!
+  arenaAddress: String!
+  cp: Int
+  win: Int!
+  lose: Int!
+  rank: Long!
+  ticket: Int!
+  ticketResetCount: Int!
+  purchasedTicketCount: Int!
+  score: Int!
+  avatar: Avatar
+}
+
+enum ItemType {
+  CONSUMABLE
+  COSTUME
+  EQUIPMENT
+  MATERIAL
+}
+
+enum ItemSubType {
+  FOOD
+  FULL_COSTUME
+  HAIR_COSTUME
+  EAR_COSTUME
+  EYE_COSTUME
+  TAIL_COSTUME
+  WEAPON
+  ARMOR
+  BELT
+  NECKLACE
+  RING
+  EQUIPMENT_MATERIAL
+  FOOD_MATERIAL
+  MONSTER_PART
+  NORMAL_MATERIAL
+  HOURGLASS
+  AP_STONE
+  CHEST
+    @deprecated(
+      reason: "ItemSubType.Chest has never been used outside the MaterialItemSheet. And we won't use it in the future until we have a specific reason."
+    )
+  TITLE
+  AURA
+  GRIMOIRE
+}
+
+enum BattleType {
+  ADVENTURE
+  ARENA
+  RAID
+  END
+}
+
+enum StatType {
+  NONE
+  HP
+  ATK
+  DEF
+  CRI
+  HIT
+  SPD
+  DRV
+  DRR
+  CDMG
+  ARMOR_PENETRATION
+  THORN
+}
+
+"""
+The built-in `Decimal` scalar type.
+"""
+scalar Decimal
+
+enum RuneSlotType {
+  DEFAULT
+  NCG
+  STAKE
+  CRYSTAL
+}
+
+enum RuneType {
+  STAT
+  SKILL
+}
+
+enum ArenaType {
+  OFF_SEASON
+  SEASON
+  CHAMPIONSHIP
+}
+
+type Avatar {
+  agentAddress: String!
+  avatarAddress: String!
+  avatarName: String!
+  level: Int!
+  actionPoint: Int!
+  dailyRewardReceivedIndex: Long!
+}

--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,16 @@ const nextConfig = {
         source: "/rank",
         destination: "/9c-main/rank",
         permanent: true,
+      },
+      {
+        source: '/odin-main/:path*',
+        destination: "/odin/:path*",
+        permanent: true
+      },
+      {
+        source: '/heimdall-main/:path*',
+        destination: "/heimdall/:path*",
+        permanent: true
       }
     ]
   }

--- a/pages/[network]/agent/[address].tsx
+++ b/pages/[network]/agent/[address].tsx
@@ -1,5 +1,4 @@
 import type { NextPage, GetServerSideProps } from "next"
-import { getPlanetName, getNodeType } from "../../../utils/network";
 import { getGraphQLSDK } from "../../../utils/mimirGraphQLClient";
 
 interface Agent {
@@ -74,10 +73,8 @@ export const getServerSideProps: GetServerSideProps<AgentPageProps> = async (con
         throw new Error("Address parameter is not a string.");
     }
 
-    const nodeType = getNodeType(network);
-    const planetName = getPlanetName(network);
-    const sdk = getGraphQLSDK(nodeType);
-    const agentJsonObj = (await sdk.GetAgent({ agentAddress: address, planetName, })).agent;
+    const sdk = getGraphQLSDK(network);
+    const agentJsonObj = (await sdk.GetAgent({ agentAddress: address, })).agent;
     if (agentJsonObj === null || agentJsonObj === undefined) {
         return {
             props: {

--- a/pages/[network]/avatar/[address].tsx
+++ b/pages/[network]/avatar/[address].tsx
@@ -1,9 +1,8 @@
 import type { NextPage, GetServerSideProps } from "next";
-import { getBalance } from "../../../utils/apiClient";
+import { getBalance, PlanetName } from "../../../utils/apiClient";
 import { getGraphQLSDK } from "../../../utils/mimirGraphQLClient";
-import { getPlanetName, getNodeType } from "../../../utils/network";
-import { NodeType } from "../../../constants/network";
-import { PlanetName } from "../../../generated/mimir/graphql-request";
+import { getPlanetName, } from "../../../utils/network";
+import { Network } from "../../../constants/network";
 
 const AGENT_CURRENCY_TICKERS = [
     "CRYSTAL",
@@ -126,10 +125,8 @@ export const getServerSideProps: GetServerSideProps<AvatarPageProps> = async (
         throw new Error("Address parameter is not a string.");
     }
 
-    const nodeType = getNodeType(network);
-    const networkType = getPlanetName(network);
-    const avatarJsonObj = (await getGraphQLSDK(nodeType).GetAvatar({
-        planetName: networkType,
+    const planetName = getPlanetName(network);
+    const avatarJsonObj = (await getGraphQLSDK(network).GetAvatar({
         avatarAddress: address,
     })).avatar;
 
@@ -144,13 +141,11 @@ export const getServerSideProps: GetServerSideProps<AvatarPageProps> = async (
     const inventoryJsonObj = avatarJsonObj.inventory;
     const inventoryObj = parseToInventory(inventoryJsonObj);
     const agentBalanceJsonObjs = await getBalances(
-        nodeType,
-        networkType,
+        planetName,
         AGENT_CURRENCY_TICKERS,
         avatarJsonObj.agentAddress);
     const avatarBalanceJsonObjs = await getBalances(
-        nodeType,
-        networkType,
+        planetName,
         AVATAR_CURRENCY_TICKERS,
         address);
 
@@ -184,8 +179,7 @@ export const getServerSideProps: GetServerSideProps<AvatarPageProps> = async (
     }
 
     async function getBalances(
-        nodeType: NodeType,
-        networkType: PlanetName,
+        network: Network,
         tickers: readonly string[],
         address: any | null
     ): Promise<FAV[]> {
@@ -196,8 +190,7 @@ export const getServerSideProps: GetServerSideProps<AvatarPageProps> = async (
         const balanceJsonObjects = await Promise.all(
             tickers.map(
                 ticker => getBalance(
-                    nodeType,
-                    networkType,
+                    network,
                     address,
                     ticker
                 )

--- a/pages/[network]/tablesheet/index.tsx
+++ b/pages/[network]/tablesheet/index.tsx
@@ -2,17 +2,12 @@ import type { NextPage, GetServerSideProps } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { getGraphQLSDK } from "../../../utils/mimirGraphQLClient";
-import { getPlanetName, getNodeType } from "../../../utils/network";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const network_info = context.query.network as string;
+  const network = context.query.network as string;
 
   try {
-    const sheetNames = (await getGraphQLSDK(
-      getNodeType(network_info),
-    ).GetSheetNames({
-      planetName: getPlanetName(network_info),
-    })).sheetNames;
+    const sheetNames = (await getGraphQLSDK(network).GetSheetNames()).sheetNames;
     return { props: { sheetNames, } };
   } catch (error) {
     console.error("Error fetching sheet names:", error);

--- a/pages/[network]/tablesheet/mimir/[name].tsx
+++ b/pages/[network]/tablesheet/mimir/[name].tsx
@@ -1,6 +1,5 @@
 import type { NextPage, GetServerSideProps } from "next";
 import { getGraphQLSDK } from "../../../../utils/mimirGraphQLClient";
-import { getPlanetName, getNodeType } from "../../../../utils/network";
 
 interface TableSheetPageProps {
   tableSheet: string | null;
@@ -56,14 +55,12 @@ const TableSheetPage: NextPage<TableSheetPageProps> = ({ tableSheet }) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const network_info = context.query.network as string;
+  const network = context.query.network as string;
   const sheetName = context.query.name as string;
 
   try {
-    const sheet = (await getGraphQLSDK(
-      getNodeType(network_info),
-    ).GetSheet({
-      planetName: getPlanetName(network_info),
+    const sheet = (await getGraphQLSDK(network)
+    .GetSheet({
       sheetName: sheetName
     })).sheet.csv;
     return { props: { tableSheet: sheet } };

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -1,9 +1,10 @@
 import { GraphQLClient } from "graphql-request";
-import { NetworkType, NodeType } from "../constants/network";
-import { PlanetName, getSdk } from "../generated/mimir/graphql-request";
+import { Network } from "../constants/network";
+import { getSdk } from "../generated/mimir/graphql-request";
 
-export const BASE_URL = "https://mimir.nine-chronicles.dev/";
-export const INTERNAL_BASE_URL = "https://mimir-internal.nine-chronicles.dev/";
+export type PlanetName = "odin" | "heimdall";
+
+export const BASE_URL = "https://mimir.nine-chronicles.dev";
 
 const defaultHeaders: HeadersInit = {
   "Content-Type": "application/json",
@@ -15,18 +16,8 @@ interface FetchOptions<TBody = undefined> {
   headers?: HeadersInit;
 }
 
-function getBaseUrl(nodeType: NodeType) {
-  if (nodeType === NodeType.Main) {
-    return BASE_URL;
-  } else if (nodeType === NodeType.Internal) {
-    return INTERNAL_BASE_URL;
-  }
-
-  throw new TypeError(`Unexpected nodeType: ${nodeType}`);
-}
-
 async function fetchAPI<TResponse, TBody = undefined>(
-  nodeType: NodeType,
+  network: Network,
   endpoint: string,
   options: FetchOptions<TBody> = {}
 ): Promise<TResponse> {
@@ -39,9 +30,7 @@ async function fetchAPI<TResponse, TBody = undefined>(
       body: body ? JSON.stringify(body) : null,
     };
 
-    const url =
-      getBaseUrl(nodeType) + endpoint;
-
+    const url = `${BASE_URL}/${network}/${endpoint}`;
     const response = await fetch(url, config);
 
     if (!response.ok) {
@@ -63,15 +52,14 @@ async function fetchAPI<TResponse, TBody = undefined>(
 }
 
 export async function getBalance(
-  nodeType: NodeType,
-  networkType: PlanetName,
+  network: Network,
   address: string,
   currencyTicker: string,
 ): Promise<any | null> {
   try {
     return await fetchAPI<any>(
-      nodeType,
-      `${networkType.toLowerCase()}/balances/${address}/${currencyTicker}`
+      network,
+      `/balances/${address}/${currencyTicker}`
     );
   } catch (error) {
     return null;
@@ -79,11 +67,11 @@ export async function getBalance(
 }
 
 // GraphQL
-function getGraphQLEndpoint(nodeType: NodeType) {
-  return `${getBaseUrl(nodeType)}/graphql`;
-}
+// function getGraphQLEndpoint(network: Network) {
+//   return `${BASE_URL}/${network}/graphql`;
+// }
 
-export function getGraphQLSDK(nodeType: NodeType) {
-  const client = new GraphQLClient(getGraphQLEndpoint(nodeType));
-  return getSdk(client);
-}
+// export function getGraphQLSDK(network: Network) {
+//   const client = new GraphQLClient(getGraphQLEndpoint(network));
+//   return getSdk(client);
+// }

--- a/utils/mimirGraphQLClient.ts
+++ b/utils/mimirGraphQLClient.ts
@@ -1,8 +1,8 @@
 import { GraphQLClient } from "graphql-request";
-import { NodeType } from "../constants/network";
+import { Network } from "../constants/network";
 import { getSdk } from "../generated/mimir/graphql-request";
 
-function getUrl(nodeType: NodeType) {
+function getUrl(network: Network) {
   const map = process.env.MIMIR_GRAPHQL_URL_MAP;
   if (map === undefined) {
     throw new Error("MIMIR_GRAPHQL_URL_MAP is not set.");
@@ -23,19 +23,19 @@ function getUrl(nodeType: NodeType) {
     return pair.split("=");
   });
   for (const [key, value] of pairs) {
-    if (key === nodeType) {
+    if (key === network) {
       return value;
     }
   }
 
-  throw new Error("There is no such network: " + nodeType);
+  throw new Error("There is no such network: " + network);
 }
 
-export function getClient(nodeType: NodeType) {
-  const url = getUrl(nodeType);
+export function getClient(network: Network) {
+  const url = getUrl(network);
   return new GraphQLClient(url, { errorPolicy: "ignore" });
 }
 
-export function getGraphQLSDK(nodeType: NodeType) {
-  return getSdk(getClient(nodeType));
+export function getGraphQLSDK(network: Network) {
+  return getSdk(getClient(network));
 }

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -1,22 +1,11 @@
-import { NodeType } from "../constants/network";
-import { PlanetName } from "../generated/mimir/graphql-request";
+import { PlanetName } from "./apiClient";
 
 export function getPlanetName(network: string): PlanetName {
-  if (network.toLowerCase().includes(PlanetName.Odin.toLowerCase())) {
-    return PlanetName.Odin;
-  } else if (network.toLowerCase().includes(PlanetName.Heimdall.toLowerCase())) {
-    return PlanetName.Heimdall;
+  if (network.toLowerCase().includes("odin")) {
+    return "odin";
+  } else if (network.toLowerCase().includes("heimdall")) {
+    return "heimdall";
   } else {
     throw new Error();
-  }
-}
-
-export function getNodeType(node: string): NodeType {
-  if (node.includes(NodeType.Internal)) {
-    return NodeType.Internal;
-  } else if (node.includes(NodeType.Main)) {
-    return NodeType.Main;
-  } else {
-    throw new Error(node);
   }
 }


### PR DESCRIPTION
First, I'm sorry to make a big one commit. 😥 But I'll write detailed explanations about changes.

## Network

This part is the most important in this pull request. Since https://github.com/planetarium/mimir/pull/189, MImir became to handle one network per one instance. And they have each endpoint and they are separated by the first path parameter (`https://mimir.nine-chronicles.dev/<network>`).

When I made the changes, I thought internal mimir and mainnet mimir can be merged into one url. In other words, I expected `https://internal-mimir.nine-chronicles.dev/heimdall` to become `https://mimir.nine-chronicles.dev/heimdall-internal` because `https://mimir.nine-chronicles.dev` is just a root url not mimir instance.

We kept `MIMIR_GRAPHQL_URL_MAP` because you can still put your own hosted mimirs in it, but we simplified the complexity of splitting internal mimirs and mimirs and interpreting them as `NodeType` and `PlanetName`.

In the process, I simply changed the original `odin-main` back to `odin`. I also redirected `odin-main` to `odin` to avoid breaking links for existing users and heimdall. Check out the changes to the following.config.js file. I've also fixed it in the README.

## Documentation

I have changes documentations:

- Correct deprecated url, `https://planetarium-9c-board.netlify.app/` → `https://9c-board.nine-chronicles.dev/`
- Describe missing `MIMIR_GRAPHQL_URL_MAP` environment variable too.