### PR TITLE
Fix typos detected by typos workflow

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,4 @@
+[files]
+extend-exclude = [
+    "graphql/*"
+]

--- a/pages/[network]/stake/[address].tsx
+++ b/pages/[network]/stake/[address].tsx
@@ -63,7 +63,7 @@ const StakePage: NextPage<StakePageProps> = ({ stakeState, blockIndex }) => {
             <div>
                 <p>Version: {stakeState.version}</p>
                 <p>Deposit: {stakeState.deposit}</p>
-                <p>StartedBlcokIndex: {stakeState.startedBlockIndex}</p>
+                <p>StartedBlockIndex: {stakeState.startedBlockIndex}</p>
                 <p>ReceivedBlockIndex: {stakeState.receivedBlockIndex}</p>
                 <div>
                     <h3>Contract</h3>


### PR DESCRIPTION
Resolving issue #68 

**Description**
Commit for https://github.com/planetarium/9c-board/issues/61 introduces typos workflow but it fails with red X mark ❌ . It is because there are some typos in the code base.

**Changes**
Handle typos detected in https://github.com/planetarium/9c-board/actions/runs/11230002273/job/31216611628?pr=67 